### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     var content = message.content ? `${ message.content }` : "";
     var img = message.image ? `<img src= ${ message.image }>` : "";
-    var html = `<div class= "message" data-id="${message.id}">
+    var html = `<div class= "message" data-message-id=` + message.id + `>
                  <div class= "upper-message">
                    <p class= "upper-message__user-name">
                      ${message.user_name}
@@ -45,4 +45,32 @@ $(function(){
       alert("メッセージ送信に失敗しました");
   });
   })
-})
+
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0){
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
+      $("#new_message")[0].reset();
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $(".form__submit").prop("disabled", false);
+    }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -13,7 +13,7 @@
 
   .messages
     - @messages.each do |message|
-      .message
+      .message{data: {message: {id: message.id}}}
         .upper-message
           .upper-message__user-name
             = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
-  
-
 end


### PR DESCRIPTION
#What
チャットが自動で更新されるようにする

#Why
別のユーザーの投稿メッセージはリロードしなければ表示されない。
これではチャットとは言えないので、自動でチャット画面が更新されるようにする。

![同期](https://user-images.githubusercontent.com/57203539/71458297-714bab80-27e5-11ea-9b99-af61a5443cbc.gif)
